### PR TITLE
Update 14Feb2021_v1.0.0.ino

### DIFF
--- a/14Feb2021_v1.0.0.ino
+++ b/14Feb2021_v1.0.0.ino
@@ -108,4 +108,5 @@ unsigned long Current_LCD_Millis = millis();
 //  digitalWrite(ENABLE, LOW); // disables the relay
 //  delay(5000); // wait 5 seconds  
 
+    
 }


### PR DESCRIPTION
as noted on the original [release](https://github.com/Glliw/Arduino-WIFI-Garage-Heater/commit/3b52ec350e78e1bcf160fc5b2c47de88eb7113d6),  heater on for 1 hour duration functionality now works.  Used an if statement in the Blynk V8 pin status call, calling the appropriate functions.  It took a little while to get the kinks worked out but seems to be working well.

